### PR TITLE
fix: 여행 상세 조회 응답에 isJoined 필드 추가

### DIFF
--- a/api/src/main/java/com/tago/api/common/mapper/PlaceDtoMapper.java
+++ b/api/src/main/java/com/tago/api/common/mapper/PlaceDtoMapper.java
@@ -7,7 +7,8 @@ public class PlaceDtoMapper {
 
     public static PlaceInfoResponse mapToplaceInfoResponse(Place place) {
         return PlaceInfoResponse.builder()
-                .id(place.getContentId())
+                .id(place.getId())
+                .contentId(place.getContentId())
                 .typeId(String.valueOf(place.getTypeId()))
                 .title(place.getTitle())
                 .overview(place.getOverview())

--- a/api/src/main/java/com/tago/api/common/mapper/TripStatusDtoMapper.java
+++ b/api/src/main/java/com/tago/api/common/mapper/TripStatusDtoMapper.java
@@ -1,0 +1,40 @@
+package com.tago.api.common.mapper;
+
+import com.tago.api.common.util.TimeUtil;
+import com.tago.api.trip.dto.response.TripStatusResponse;
+import com.tago.domain.member.domain.vo.Gender;
+import com.tago.domain.trip.domain.Trip;
+import com.tago.domain.tripmember.dto.TripMemberDto;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class TripStatusDtoMapper {
+
+    public static TripStatusResponse toDto(Trip trip, List<TripMemberDto> tripMembers) {
+        return new TripStatusResponse(
+                countGender(tripMembers, Gender.FEMALE),
+                countGender(tripMembers, Gender.MALE),
+                getAgeGroups(tripMembers),
+                TimeUtil.formatToHourMinute(trip.getDateTime()),
+                TimeUtil.formatToHourMinute(trip.getEndTime())
+        );
+    }
+
+    private static int countGender(List<TripMemberDto> tripMembers, Gender gender) {
+        return (int) tripMembers.stream()
+                .filter(tripMember -> isGenderEquals(tripMember, gender))
+                .count();
+    }
+
+    private static boolean isGenderEquals(TripMemberDto tripMember, Gender gender) {
+        return gender.isEquals(tripMember.getGender());
+    }
+
+    private static Set<Integer> getAgeGroups(List<TripMemberDto> tripMembers){
+        return tripMembers.stream()
+                .map(TripMemberDto::getAgeRange)
+                .collect(Collectors.toSet());
+    }
+}

--- a/api/src/main/java/com/tago/api/common/util/TimeUtil.java
+++ b/api/src/main/java/com/tago/api/common/util/TimeUtil.java
@@ -1,0 +1,12 @@
+package com.tago.api.common.util;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+public class TimeUtil {
+
+    public static String formatToHourMinute(LocalDateTime dateTime) {
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("HH:mm");
+        return dateTime.format(formatter);
+    }
+}

--- a/api/src/main/java/com/tago/api/place/application/PlaceService.java
+++ b/api/src/main/java/com/tago/api/place/application/PlaceService.java
@@ -24,7 +24,6 @@ public class PlaceService {
         return PageResponseDto.from(places);
     }
 
-
     public PlaceInfoResponse getPlaceInfo(Long placeId){
         Place place = placeQueryService.findById(placeId);
         return PlaceDtoMapper.mapToplaceInfoResponse(place);

--- a/api/src/main/java/com/tago/api/place/dto/response/PlaceInfoResponse.java
+++ b/api/src/main/java/com/tago/api/place/dto/response/PlaceInfoResponse.java
@@ -14,6 +14,7 @@ import org.hibernate.validator.constraints.Normalized;
 public class PlaceInfoResponse {
 
     private Long id;
+    private Long contentId;
     private String typeId;
     private String title;
     private String overview;

--- a/api/src/main/java/com/tago/api/trip/application/TripPlaceService.java
+++ b/api/src/main/java/com/tago/api/trip/application/TripPlaceService.java
@@ -5,6 +5,7 @@ import com.tago.domain.trip.domain.Trip;
 import com.tago.domain.trip.dto.TripPlaceDto;
 import com.tago.domain.trip.service.TripPlaceQueryService;
 import com.tago.domain.trip.service.TripQueryService;
+import com.tago.domain.tripmember.service.TripMemberQueryService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -17,9 +18,10 @@ public class TripPlaceService {
 
     private final TripQueryService tripQueryService;
     private final TripPlaceQueryService tripPlaceQueryService;
+    private final TripMemberQueryService tripMemberQueryService;
 
     @Transactional(readOnly = true)
-    public TripGetOneResponse getTripAndPlaces(Long tripId) {
+    public TripGetOneResponse getTripAndPlaces(Long memberId, Long tripId) {
         Trip trip = tripQueryService.findById(tripId);
         List<TripPlaceDto> tripPlaces = tripPlaceQueryService.findAll(trip);
 
@@ -27,7 +29,12 @@ public class TripPlaceService {
                 trip.getName(),
                 trip.getCurrentCnt(),
                 trip.getMaxCnt(),
+                isJoined(tripId, memberId),
                 tripPlaces
         );
+    }
+
+    private Boolean isJoined(Long tripId, Long memberId) {
+        return tripMemberQueryService.existsByTripIdAndMemberId(tripId, memberId);
     }
 }

--- a/api/src/main/java/com/tago/api/trip/application/TripService.java
+++ b/api/src/main/java/com/tago/api/trip/application/TripService.java
@@ -1,30 +1,26 @@
 package com.tago.api.trip.application;
 
 import com.tago.api.common.dto.PageResponseDto;
+import com.tago.api.common.mapper.TripStatusDtoMapper;
 import com.tago.api.trip.dto.response.TripStatusResponse;
-import com.tago.domain.member.domain.Member;
-import com.tago.domain.member.domain.vo.Gender;
 import com.tago.domain.trip.domain.Trip;
-import com.tago.domain.tripmember.domain.TripMember;
 import com.tago.domain.trip.dto.TripPreviewDto;
-import com.tago.domain.tripmember.repository.TripMemberRepository;
+import com.tago.domain.tripmember.dto.TripMemberDto;
 import com.tago.domain.trip.service.TripQueryService;
+import com.tago.domain.tripmember.service.TripMemberQueryService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 public class TripService {
 
     private final TripQueryService tripQueryService;
-    private final TripMemberRepository tripMemberRepository;
+    private final TripMemberQueryService tripMemberQueryService;
 
     @Transactional(readOnly = true)
     public PageResponseDto<TripPreviewDto> getAll(Long cursorId, LocalDateTime cursorDate, int limit) {
@@ -32,54 +28,11 @@ public class TripService {
         return PageResponseDto.from(trips);
     }
 
-    public TripStatusResponse getTripStatus(Long tripId){
-
+    @Transactional(readOnly = true)
+    public TripStatusResponse getTripStatus(Long tripId) {
         Trip trip = tripQueryService.findById(tripId);
+        List<TripMemberDto> tripMembers = tripMemberQueryService.findMembersByTrip(trip);
 
-        //해당 여행에 참여하는 사람들 조회
-        List<TripMember> tripMembers = tripMemberRepository.findByTripId(tripId);
-
-        int femaleCnt = countGender(tripMembers,Gender.FEMALE);
-        int maleCnt = countGender(tripMembers,Gender.MALE);
-        Set<String> ageGroups = getAgeGroups(tripMembers);
-
-
-        LocalDateTime endTime = trip.getDateTime().plusHours(8);
-
-        return new TripStatusResponse(
-                femaleCnt,
-                maleCnt,
-                ageGroups,
-                formatToHourMinute(trip.getDateTime()),
-                formatToHourMinute(endTime)
-        );
-
+        return TripStatusDtoMapper.toDto(trip, tripMembers);
     }
-
-    //성별 count
-    private int countGender(List<TripMember> tripMembers, Gender gender) {
-        return (int) tripMembers.stream()
-                .map(TripMember::getMember)
-                .map(Member::getProfile)
-                .filter(profile -> profile.getGender() == gender)
-                .count();
-    }
-
-    private Set<String> getAgeGroups(List<TripMember> tripMembers){
-        return tripMembers.stream()
-                .map(TripMember::getMember)
-                .map(Member::getProfile)
-                .map(profile -> calAgeGroup(profile.getAgeRange()))
-                .collect(Collectors.toSet());
-    }
-
-    private String calAgeGroup(int ageRange){
-        return ageRange+"대";
-    }
-
-    private String formatToHourMinute(LocalDateTime dateTime) {
-        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("HH:mm");
-        return dateTime.format(formatter);
-    }
-
 }

--- a/api/src/main/java/com/tago/api/trip/dto/response/TripGetOneResponse.java
+++ b/api/src/main/java/com/tago/api/trip/dto/response/TripGetOneResponse.java
@@ -14,5 +14,6 @@ public class TripGetOneResponse {
     private String tripName;
     private int currentCnt;
     private int maxCnt;
+    private Boolean isJoined;
     private List<TripPlaceDto> places;
 }

--- a/api/src/main/java/com/tago/api/trip/dto/response/TripStatusResponse.java
+++ b/api/src/main/java/com/tago/api/trip/dto/response/TripStatusResponse.java
@@ -13,7 +13,7 @@ public class TripStatusResponse {
 
     private int femaleCnt;
     private int maleCnt;
-    private Set<String> ageGroup;
+    private Set<Integer> ageGroup;
     private String startTime;
     private String endTime;
 

--- a/api/src/main/java/com/tago/api/trip/presentation/TripController.java
+++ b/api/src/main/java/com/tago/api/trip/presentation/TripController.java
@@ -1,5 +1,6 @@
 package com.tago.api.trip.presentation;
 
+import com.tago.api.common.annotation.LoginMember;
 import com.tago.api.common.dto.PageResponseDto;
 import com.tago.api.common.dto.ResponseDto;
 import com.tago.api.trip.application.TripPlaceService;
@@ -31,18 +32,20 @@ public class TripController {
         return ResponseDto.ok(response);
     }
 
-
-    @GetMapping("trips/{tripId}/status")
-    public ResponseEntity<TripStatusResponse> getTripStatus(@PathVariable Long tripId){
-        TripStatusResponse tripStatus = tripService.getTripStatus(tripId);
-        return ResponseDto.ok(tripStatus);
-    }
-      
     @GetMapping("/trips/{tripId}")
     public ResponseEntity<TripGetOneResponse> getOne(
+            @LoginMember Long memberId,
             @PathVariable Long tripId
     ) {
-        TripGetOneResponse response = tripPlaceService.getTripAndPlaces(tripId);
+        TripGetOneResponse response = tripPlaceService.getTripAndPlaces(memberId, tripId);
         return ResponseDto.ok(response);
+    }
+
+    @GetMapping("trips/{tripId}/status")
+    public ResponseEntity<TripStatusResponse> getTripStatus(
+            @PathVariable Long tripId
+    ){
+        TripStatusResponse tripStatus = tripService.getTripStatus(tripId);
+        return ResponseDto.ok(tripStatus);
     }
 }

--- a/api/src/main/resources/data.sql
+++ b/api/src/main/resources/data.sql
@@ -30,5 +30,4 @@ insert into trip_place values(6, 2, 2, 2);
 
 -- INSERT TRIP_MEMBER
 insert into trip_member values(1, 1, 1);
-insert into trip_member values(2, 2, 1);
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,3 @@
+ARG ELK_VERSION
+FROM docker.elastic.co/elasticsearch/elasticsearch:${ELK_VERSION}
+RUN elasticsearch-plugin install analysis-nori

--- a/docker/docker-compose.elastic.yml
+++ b/docker/docker-compose.elastic.yml
@@ -1,0 +1,32 @@
+version: '3.7'
+
+services:
+  elasticsearch:
+    build:
+      context: .
+      args:
+        ELK_VERSION: 8.7.0
+    container_name: elasticsearch
+    environment:
+      - node.name=single-node
+      - cluster.name=tago
+      - discovery.type=single-node
+      - xpack.security.enabled=false
+      - xpack.security.http.ssl.enabled=false
+      - xpack.security.transport.ssl.enabled=false
+    ports:
+      - "9200:9200"
+      - "9300:9300"
+
+  kibana:
+    container_name: kibana
+    image: docker.elastic.co/kibana/kibana:8.7.0
+    environment:
+      SERVER_NAME: kibana
+      ELASTICSEARCH_HOSTS: http://elasticsearch:9200
+    ports:
+      - "5601:5601"
+    depends_on:
+      - elasticsearch
+
+# docker-compose -f docker-compose.elastic.yml up -d

--- a/domain/src/main/java/com/tago/domain/member/domain/vo/Gender.java
+++ b/domain/src/main/java/com/tago/domain/member/domain/vo/Gender.java
@@ -24,4 +24,8 @@ public enum Gender {
                 .findFirst()
                 .orElseThrow(() -> new EnumNotFoundException(ErrorCode.GENDER_NOT_FOUND));
     }
+
+    public boolean isEquals(String gender) {
+        return this.description.equals(gender);
+    }
 }

--- a/domain/src/main/java/com/tago/domain/trip/domain/Trip.java
+++ b/domain/src/main/java/com/tago/domain/trip/domain/Trip.java
@@ -65,4 +65,8 @@ public class Trip {
     private boolean isLimitMember() {
         return this.currentCnt >= this.maxCnt;
     }
+
+    public LocalDateTime getEndTime() {
+        return this.dateTime.plusMinutes(totalTime);
+    }
 }

--- a/domain/src/main/java/com/tago/domain/trip/repository/TripPlaceCustomRepository.java
+++ b/domain/src/main/java/com/tago/domain/trip/repository/TripPlaceCustomRepository.java
@@ -8,5 +8,5 @@ import java.util.List;
 
 public interface TripPlaceCustomRepository {
 
-    List<TripPlaceDto> findAllByTripFetchPlace(Trip trip);
+    List<TripPlaceDto> findAllByTrip(Trip trip);
 }

--- a/domain/src/main/java/com/tago/domain/trip/repository/impl/TripPlaceCustomRepositoryImpl.java
+++ b/domain/src/main/java/com/tago/domain/trip/repository/impl/TripPlaceCustomRepositoryImpl.java
@@ -21,7 +21,7 @@ public class TripPlaceCustomRepositoryImpl implements TripPlaceCustomRepository 
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public List<TripPlaceDto> findAllByTripFetchPlace(Trip trip) {
+    public List<TripPlaceDto> findAllByTrip(Trip trip) {
         return queryFactory.select(new QTripPlaceDto(
                     place.id,
                     place.title,

--- a/domain/src/main/java/com/tago/domain/trip/service/TripPlaceQueryService.java
+++ b/domain/src/main/java/com/tago/domain/trip/service/TripPlaceQueryService.java
@@ -15,6 +15,6 @@ public class TripPlaceQueryService {
     private final TripPlaceRepository tripPlaceRepository;
 
     public List<TripPlaceDto> findAll(Trip trip) {
-        return tripPlaceRepository.findAllByTripFetchPlace(trip);
+        return tripPlaceRepository.findAllByTrip(trip);
     }
 }

--- a/domain/src/main/java/com/tago/domain/tripmember/dto/TripMemberDto.java
+++ b/domain/src/main/java/com/tago/domain/tripmember/dto/TripMemberDto.java
@@ -29,7 +29,7 @@ public class TripMemberDto {
         this.name = name;
         this.mbti = mbti.name();
         this.ageRange = ageRange;
-        this.gender = gender.name();
+        this.gender = gender.getDescription();
         this.tripTypes = TripType.toSentence(tripTypes);
     }
 }

--- a/domain/src/main/java/com/tago/domain/tripmember/repository/TripMemberRepository.java
+++ b/domain/src/main/java/com/tago/domain/tripmember/repository/TripMemberRepository.java
@@ -7,5 +7,5 @@ import java.util.List;
 
 public interface TripMemberRepository extends JpaRepository<TripMember,Long>, TripMemberCustomRepository {
 
-    List<TripMember> findByTripId(Long tripId);
+    Boolean existsByTripIdAndMemberId(Long tripId, Long memberId);
 }

--- a/domain/src/main/java/com/tago/domain/tripmember/service/TripMemberQueryService.java
+++ b/domain/src/main/java/com/tago/domain/tripmember/service/TripMemberQueryService.java
@@ -25,4 +25,8 @@ public class TripMemberQueryService {
     public List<TripMemberDto> findMembersByTrip(Trip trip) {
         return tripMemberRepository.findMembersByTrip(trip);
     }
+
+    public Boolean existsByTripIdAndMemberId(Long tripId, Long memberId) {
+        return tripMemberRepository.existsByTripIdAndMemberId(tripId, memberId);
+    }
 }


### PR DESCRIPTION
## Issue
* resolved #39 
* resolved #48 

## 작업 사항
* 여행 상세 조회 `/api/v1/trips/{tripId}` 응답에 여행 참여 여부 flag값(isJoined) 추가
* place 상세 조회 응답값 수정
* elastic search, kibana docker compose 작성
* 여행 상태 조회 `/api/v1/trips/{tripId}/status` 리팩토링
  * entity -> dto 변환 로직 mapper 객체로 리팩토링
  * trip에 참여한 member 정보를 가져올 때 즉, trip에 대한 tripMember 조회 후, 각 member의 정보를 가져올 때 N+1 문제 발생
  * tripMember, member Join을 통해 trip에 참여한 member를 한번에 가져온 뒤, member에 대한 DTO를 반환하도록 수정해 문제해결