### PR TITLE
chore: tomcat connection time 변경

### DIFF
--- a/api/src/main/resources/application.yml
+++ b/api/src/main/resources/application.yml
@@ -24,6 +24,10 @@ spring:
       host: ${REDIS_HOST}
       port: ${REDIS_PORT}
 
+server:
+  tomcat:
+    connection-timeout: 300s
+
 jwt:
   secretKey: ${JWT_SECRET_KEY}
 


### PR DESCRIPTION
## Issue
* resolved #104 

## 작업 사항
* Tomcat connection timeout 속성은 웹 연결 후 연결이 닫히기 전에 클라이언트가 요청을 할 때까지 서버가 기다리는 최대 시간을 나타낸다.
* ELB의 유휴 제한 시간(timeout)보다 tomcat timeout시간이 짧아서 504 bad gateway가 발생함 (ELB의 유휴 제한 시간은 180초)
* tomcat timeout 기본값은 60000(60초)이지만, tomcat을 server.xml로 구성한 경우 timeout 기본값은 20000(20초)이다.
    * Spring은 외장톰캣 구성요소를 server.xml 을 작성하여 구성
    * Spring boot에서 또한 내장톰캣의 구성요소를 application.properties(yml)에서 구성
    * 즉, 현재 Spring boot의 tomcat timeout은 20000(20초)로 되어있다.
* 따라서 ELB의 유휴 제한 시간보다 큰값을 갖도록 tomcat timeout을 300초로 수정