### PR TITLE
fix: 동성만 필터 여행 전체 조회 쿼리 수정

### DIFF
--- a/api/src/main/java/com/tago/api/trip/application/TripGetService.java
+++ b/api/src/main/java/com/tago/api/trip/application/TripGetService.java
@@ -36,7 +36,7 @@ public class TripGetService {
             Long cursorId, LocalDateTime cursorDate, int limit, Boolean sameGender, Boolean isPet, Long memberId
     ) {
         Member member = memberQueryService.findByIdFetchMemberTag(memberId);
-        List<Trip> trips = tripQueryService.findAll(cursorId, cursorDate, limit, sameGender, isPet);
+        List<Trip> trips = tripQueryService.findAll(cursorId, cursorDate, limit, sameGender, isPet, member.getGender());
         List<TripGetResponse> dto = TripDtoMapper.toDto(trips, member);
         return PageResponseDto.from(dto);
     }

--- a/domain/src/main/java/com/tago/domain/trip/handler/TripQueryService.java
+++ b/domain/src/main/java/com/tago/domain/trip/handler/TripQueryService.java
@@ -2,6 +2,7 @@ package com.tago.domain.trip.handler;
 
 import com.tago.domain.driver.domain.Driver;
 import com.tago.domain.member.domain.Member;
+import com.tago.domain.member.domain.vo.Gender;
 import com.tago.domain.trip.domain.Trip;
 import com.tago.domain.trip.exception.TripNotFoundException;
 import com.tago.domain.trip.repository.TripRepository;
@@ -27,8 +28,8 @@ public class TripQueryService {
                 .orElseThrow(TripNotFoundException::new);
     }
   
-    public List<Trip> findAll(Long cursorId, LocalDateTime cursorDate, int limit, Boolean sameGender, Boolean isPet) {
-        return tripRepository.findAll(cursorId, cursorDate, limit, sameGender, isPet);
+    public List<Trip> findAll(Long cursorId, LocalDateTime cursorDate, int limit, Boolean sameGender, Boolean isPet, Gender memberGender) {
+        return tripRepository.findAll(cursorId, cursorDate, limit, sameGender, isPet, memberGender);
     }
 
     public List<Trip> findAllByNotDispatch(Long cursorId, LocalDateTime cursorDate, int limit) {

--- a/domain/src/main/java/com/tago/domain/trip/repository/TripCustomRepository.java
+++ b/domain/src/main/java/com/tago/domain/trip/repository/TripCustomRepository.java
@@ -2,6 +2,7 @@ package com.tago.domain.trip.repository;
 
 import com.tago.domain.driver.domain.Driver;
 import com.tago.domain.member.domain.Member;
+import com.tago.domain.member.domain.vo.Gender;
 import com.tago.domain.trip.domain.Trip;
 
 import java.time.LocalDateTime;
@@ -10,7 +11,7 @@ import java.util.Optional;
 
 public interface TripCustomRepository {
 
-    List<Trip> findAll(Long cursorId, LocalDateTime cursorDate, int limit, Boolean sameGender, Boolean isPet);
+    List<Trip> findAll(Long cursorId, LocalDateTime cursorDate, int limit, Boolean sameGender, Boolean isPet, Gender memberGender);
     List<Trip> findByPlaceTitleKeywordContain(String keyword, Long cursorId, LocalDateTime cursorDate, int limit);
 
     Trip findByTripTag(Long memberId);


### PR DESCRIPTION
## Issue
* resolved #128 

## 작업 사항
* 필터 없을 때 : 동성 상관없어요 + 여행 생성자랑 사용자가 같은 성별인 여행(동성만)
* 필터 있을 때 : 여행 생성자랑 사용자가 같은 성별인 여행(동성만)