### PR TITLE
fix: driver 정보 조회 API 권한 수정

### DIFF
--- a/api/src/main/java/com/tago/api/driver/application/DriverService.java
+++ b/api/src/main/java/com/tago/api/driver/application/DriverService.java
@@ -1,8 +1,10 @@
 package com.tago.api.driver.application;
 
 import com.tago.api.driver.dto.response.DriverGetResponse;
+import com.tago.domain.driver.domain.Dispatch;
 import com.tago.domain.driver.domain.Driver;
 import com.tago.domain.driver.dto.DriverInfoDto;
+import com.tago.domain.driver.handler.DispatchQueryService;
 import com.tago.domain.driver.handler.DriverQueryService;
 import com.tago.domain.trip.domain.Trip;
 import com.tago.domain.trip.handler.TripQueryService;
@@ -14,13 +16,15 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class DriverService {
 
-    private final DriverQueryService driverQueryService;
     private final TripQueryService tripQueryService;
+    private final DriverQueryService driverQueryService;
+    private final DispatchQueryService dispatchQueryService;
 
     @Transactional(readOnly = true)
-    public DriverInfoDto getByTrip(Long tripId, Long driverId) {
+    public DriverInfoDto getByTrip(Long tripId) {
         Trip trip = tripQueryService.findById(tripId);
-        return driverQueryService.findById(trip.getCurrentCnt(), driverId);
+        Dispatch dispatch = dispatchQueryService.findByTrip(trip);
+        return driverQueryService.findByDriverAndCar(trip.getCurrentCnt(), dispatch.getDriver());
     }
 
     @Transactional(readOnly = true)

--- a/api/src/main/java/com/tago/api/driver/presentation/DriverApi.java
+++ b/api/src/main/java/com/tago/api/driver/presentation/DriverApi.java
@@ -21,10 +21,9 @@ public class DriverApi {
 
     @GetMapping("/trips/{tripId}/driver")
     public ResponseEntity<DriverInfoDto> getByTrip(
-            @PathVariable("tripId") Long tripId,
-            @DriverAuthentication Long driverId
+            @PathVariable("tripId") Long tripId
     ) {
-        DriverInfoDto response = driverService.getByTrip(tripId, driverId);
+        DriverInfoDto response = driverService.getByTrip(tripId);
         return ResponseDto.ok(response);
     }
 

--- a/domain/src/main/java/com/tago/domain/driver/handler/DispatchQueryService.java
+++ b/domain/src/main/java/com/tago/domain/driver/handler/DispatchQueryService.java
@@ -29,4 +29,9 @@ public class DispatchQueryService {
     public Boolean existsTripIdAndDriverId(Long tripId, Long driverId) {
         return dispatchRepository.existsByTripIdAndDriverId(tripId, driverId);
     }
+
+    public Dispatch findByTrip(Trip trip) {
+        return dispatchRepository.findByTrip(trip)
+                .orElseThrow(DispatchNotFoundException::new);
+    }
 }

--- a/domain/src/main/java/com/tago/domain/driver/handler/DriverQueryService.java
+++ b/domain/src/main/java/com/tago/domain/driver/handler/DriverQueryService.java
@@ -23,8 +23,8 @@ public class DriverQueryService {
                 .orElseThrow(DriverNotFoundException::new);
     }
 
-    public DriverInfoDto findById(int cnt, Long id) {
-        return driverRepository.findById(cnt, id)
+    public DriverInfoDto findByDriverAndCar(int cnt, Driver driver) {
+        return driverRepository.findByDriverAndCar(cnt, driver)
                 .orElseThrow(DriverNotFoundException::new);
     }
 }

--- a/domain/src/main/java/com/tago/domain/driver/repository/DriverCustomRepository.java
+++ b/domain/src/main/java/com/tago/domain/driver/repository/DriverCustomRepository.java
@@ -1,9 +1,10 @@
 package com.tago.domain.driver.repository;
 
+import com.tago.domain.driver.domain.Driver;
 import com.tago.domain.driver.dto.DriverInfoDto;
 
 import java.util.Optional;
 
 public interface DriverCustomRepository {
-    Optional<DriverInfoDto> findById(int cnt, Long driverId);
+    Optional<DriverInfoDto> findByDriverAndCar(int cnt, Driver driver);
 }

--- a/domain/src/main/java/com/tago/domain/driver/repository/impl/DriverCustomRepositoryImpl.java
+++ b/domain/src/main/java/com/tago/domain/driver/repository/impl/DriverCustomRepositoryImpl.java
@@ -2,6 +2,8 @@ package com.tago.domain.driver.repository.impl;
 
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.tago.domain.driver.domain.Driver;
+import com.tago.domain.driver.domain.QDriver;
 import com.tago.domain.driver.dto.DriverInfoDto;
 import com.tago.domain.driver.dto.QDriverInfoDto;
 import com.tago.domain.driver.repository.DriverCustomRepository;
@@ -20,26 +22,26 @@ public class DriverCustomRepositoryImpl implements DriverCustomRepository {
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public Optional<DriverInfoDto> findById(int cnt, Long driverId) {
+    public Optional<DriverInfoDto> findByDriverAndCar(int cnt, Driver driver) {
         return Optional.ofNullable(queryFactory.select(new QDriverInfoDto(
-                        driver.info.imgUrl,
-                        driver.info.name,
-                        driver.info.comment,
-                        driver.info.phoneNumber,
-                        driver.info.license,
+                        QDriver.driver.info.imgUrl,
+                        QDriver.driver.info.name,
+                        QDriver.driver.info.comment,
+                        QDriver.driver.info.phoneNumber,
+                        QDriver.driver.info.license,
                         car.seater,
                         car.number
                  ))
-                .from(driver)
-                .innerJoin(driver.cars, car)
+                .from(QDriver.driver)
+                .innerJoin(QDriver.driver.cars, car)
                 .where(
-                        driverIdEq(driverId),
+                        driverEq(driver),
                         carSeaterEq(cnt)
                 ).fetchOne());
     }
 
-    private BooleanExpression driverIdEq(Long driverId) {
-        return driver.id.eq(driverId);
+    private BooleanExpression driverEq(Driver driver) {
+        return QDriver.driver.eq(driver);
     }
 
     private BooleanExpression carSeaterEq(int cnt) {


### PR DESCRIPTION
## 작업 사항
* 기존의 Driver 정보 조회 API는 @DriverAuthentication 어노테이션을 사용했음
* Driver Argument Resolver를 거친다. 여기서는 Jwt 토큰의 Role을 확인하고, Driver가 아니면 exception 발생
* 따라서, User가 User Role의 Jwt 토큰을 갖고 driver 정보를 조회하는 경우 권한 없음 exception 발생
* 이를 해결하기 위해 @DriverAuthentication을 제외하고, driver 정보 조회 API 비즈니스 로직 수정
  * pathvariable로 받은 tripId로 dispatch(배차 정보)를 조회하고, 해당 배차 Driver 정보를 조회하는 방식으로 수정