### PR TITLE
fix: verify-code API 응답에 회원가입 여부 추가

### DIFF
--- a/api/src/main/java/com/tago/api/infra/fcm/FCMClient.java
+++ b/api/src/main/java/com/tago/api/infra/fcm/FCMClient.java
@@ -21,13 +21,15 @@ public class FCMClient {
 
         String token = fcmTokenUtil.get(dto.getPhoneNumber());
         Message message = Message.builder()
+                .putData("payload", dto.getPayload())
                 .putData("title", dto.getTitle())
                 .putData("content", dto.getContent())
                 .setToken(token)
                 .build();
 
         try {
-            FirebaseMessaging.getInstance().send(message);
+            String response = FirebaseMessaging.getInstance().send(message);
+            log.info("## SUCCESS SEND FCM ## " + response);
         } catch (FirebaseMessagingException e) {
             throw new FailedSendFCMException(e);
         }

--- a/api/src/main/java/com/tago/api/infra/fcm/FCMSendDto.java
+++ b/api/src/main/java/com/tago/api/infra/fcm/FCMSendDto.java
@@ -13,4 +13,5 @@ public class FCMSendDto {
     private String title;
     private String content;
     private String phoneNumber;
+    private String payload;
 }

--- a/api/src/main/java/com/tago/api/infra/fcm/FCMService.java
+++ b/api/src/main/java/com/tago/api/infra/fcm/FCMService.java
@@ -16,6 +16,7 @@ public class FCMService {
     public void sendByTripMemberEvent(TripMemberEvent event) {
         FCMType type = FCMType.from(event.getAction());
         fcmClient.send(FCMSendDto.builder()
+                .payload(String.valueOf(event.getTripId()))
                 .title(type.getTitle())
                 .content(type.getContent(event.getName()))
                 .phoneNumber(event.getPhoneNumber())

--- a/api/src/main/java/com/tago/api/infra/fcm/FCMType.java
+++ b/api/src/main/java/com/tago/api/infra/fcm/FCMType.java
@@ -6,7 +6,7 @@ import lombok.Getter;
 import java.util.function.Function;
 @Getter
 public enum FCMType {
-    CREATE_TRIP_MEMBER("TAGO", (name) -> name + "님! 여행메이트가 한명 추가되었어요! 클릭해서 확인해보세요."),
+    CREATE_TRIP_MEMBER("TAGO", (name) -> name + "님! 여행인원이 한명 추가되었어요! 클릭해서 확인해보세요."),
     DELETE_TRIP_MEMBER("TAGO", (name) -> name + "님! 여행인원이 줄어들었어요. 클릭해서 확인해보세요."),
     COMPLETE_TRIP_MEMBER("TAGO", (name) -> name + "님! 여행인원이 모두 모집되었네요! 클릭해서 확인해보세요."),
     CREATE_DISPATCH("TAGO", (name) -> name + "님! 여행을 같이 할 기사님이 배정되었어요. 클릭해서 확인해보세요.")

--- a/api/src/main/java/com/tago/api/infra/sms/application/SmsService.java
+++ b/api/src/main/java/com/tago/api/infra/sms/application/SmsService.java
@@ -4,6 +4,7 @@ import com.tago.api.infra.sms.domain.SmsClient;
 import com.tago.api.infra.sms.domain.dto.SmsRequest;
 import com.tago.api.infra.sms.domain.dto.SmsResponse;
 import com.tago.api.infra.sms.util.VerificationCodeUtil;
+import com.tago.domain.member.handler.MemberQueryService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -13,6 +14,7 @@ public class SmsService {
 
     private final SmsClient smsClient;
     private final VerificationCodeUtil verificationCodeUtil;
+    private final MemberQueryService memberQueryService;
 
     public void send(SmsRequest.Send request) {
         smsClient.send(request);
@@ -20,7 +22,13 @@ public class SmsService {
 
     public SmsResponse.VerifyCode verifyCode(SmsRequest.VerifyCode request) {
         verificationCodeUtil.verify(request.getNumber(), request.getCode());
-        return new SmsResponse.VerifyCode(true);
+        return new SmsResponse.VerifyCode(true, isSignUp(request.getNumber()));
+    }
+
+    public Boolean isSignUp(String number) {
+        String regEx = "(\\d{3})(\\d{3,4})(\\d{4})";
+        String phoneNumber = number.replaceAll(regEx, "$1-$2-$3");
+        return memberQueryService.existsByPhoneNumber(phoneNumber);
     }
 }
 

--- a/api/src/main/java/com/tago/api/infra/sms/domain/dto/SmsResponse.java
+++ b/api/src/main/java/com/tago/api/infra/sms/domain/dto/SmsResponse.java
@@ -11,6 +11,7 @@ public class SmsResponse {
     @AllArgsConstructor
     @Schema(name = "AuthSmsVerifyCodeResponse")
     public static class VerifyCode {
-        private boolean isVerify;
+        private Boolean isVerify;
+        private Boolean isSignUp;
     }
 }

--- a/domain/src/main/java/com/tago/domain/driver/event/producer/DispatchEvent.java
+++ b/domain/src/main/java/com/tago/domain/driver/event/producer/DispatchEvent.java
@@ -8,6 +8,7 @@ import lombok.*;
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class DispatchEvent implements Event {
+    private Long tripId;
     private String phoneNumber;
     private String name;
     private Action action;

--- a/domain/src/main/java/com/tago/domain/member/handler/MemberQueryService.java
+++ b/domain/src/main/java/com/tago/domain/member/handler/MemberQueryService.java
@@ -35,4 +35,8 @@ public class MemberQueryService {
     public boolean existsById(Long memberId) {
         return memberRepository.existsById(memberId);
     }
+
+    public boolean existsByPhoneNumber(String phoneNumber) {
+        return memberRepository.existsByPhoneNumber(phoneNumber);
+    }
 }

--- a/domain/src/main/java/com/tago/domain/member/repository/MemberRepository.java
+++ b/domain/src/main/java/com/tago/domain/member/repository/MemberRepository.java
@@ -9,4 +9,5 @@ import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long>, MemberCustomRepository {
     Optional<Member> findByPhoneNumber(String phoneNumber);
+    Boolean existsByPhoneNumber(String phoneNumber);
 }

--- a/domain/src/main/java/com/tago/domain/trip/domain/Trip.java
+++ b/domain/src/main/java/com/tago/domain/trip/domain/Trip.java
@@ -94,7 +94,7 @@ public class Trip {
         this.tripMembers.addAll(tripMembers);
     }
 
-    private boolean isLimitMember() {
+    public boolean isLimitMember() {
         return this.currentCnt >= this.maxCnt;
     }
 

--- a/domain/src/main/java/com/tago/domain/tripmember/event/producer/TripMemberEvent.java
+++ b/domain/src/main/java/com/tago/domain/tripmember/event/producer/TripMemberEvent.java
@@ -9,6 +9,7 @@ import lombok.*;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 
 public class TripMemberEvent implements Event {
+    private Long tripId;
     private String name;
     private String phoneNumber;
     private Action action;

--- a/domain/src/main/java/com/tago/domain/tripmember/service/TripMemberCreateService.java
+++ b/domain/src/main/java/com/tago/domain/tripmember/service/TripMemberCreateService.java
@@ -3,11 +3,9 @@ package com.tago.domain.tripmember.service;
 
 import com.tago.domain.member.domain.Member;
 import com.tago.domain.trip.domain.Trip;
-import com.tago.domain.tripmember.domain.TripMember;
 import com.tago.domain.tripmember.event.producer.TripMemberEvent;
 import com.tago.domain.tripmember.event.producer.TripMemberEventProducer;
 import com.tago.domain.tripmember.exception.AlreadyExistsTripMemberException;
-import com.tago.domain.tripmember.handler.TripMemberQueryService;
 import com.tago.domain.tripmember.service.factory.TripMemberService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -28,8 +26,8 @@ public class TripMemberCreateService implements TripMemberService {
     @Override
     public void action(Trip trip, Member member) {
         validateJoinedAble(trip, member);
-        trip.getTripMembers().forEach(this::publish);
         trip.join(member);
+        publishEvent(trip, member);
     }
 
     private void validateJoinedAble(Trip trip, Member member) {
@@ -38,13 +36,27 @@ public class TripMemberCreateService implements TripMemberService {
         }
     }
 
-    private void publish(TripMember tripMember) {
+    private void publishEvent(Trip trip, Member member) {
+        trip.getTripMembers().stream()
+                .filter(tripMember -> !tripMember.getMember().equals(member))
+                .forEach(tripMember -> publish(trip, tripMember.getMember(), getEventAction(trip)));
+    }
+
+    private void publish(Trip trip, Member member, TripMemberEvent.Action action) {
         tripMemberEventProducer.produceEvent(TripMemberEvent.builder()
-                .name(tripMember.getMember().getName())
-                .phoneNumber(tripMember.getMember().getPhoneNumber())
-                .action(TripMemberEvent.Action.CREATE)
+                .tripId(trip.getId())
+                .name(member.getName())
+                .phoneNumber(member.getPhoneNumber())
+                .action(action)
                 .build()
         );
+    }
+
+    private TripMemberEvent.Action getEventAction(Trip trip) {
+        if (trip.isLimitMember()) {
+            return TripMemberEvent.Action.COMPLETE;
+        }
+        return TripMemberEvent.Action.CREATE;
     }
 }
 

--- a/domain/src/main/java/com/tago/domain/tripmember/service/TripMemberDeleteService.java
+++ b/domain/src/main/java/com/tago/domain/tripmember/service/TripMemberDeleteService.java
@@ -28,13 +28,14 @@ public class TripMemberDeleteService implements TripMemberService {
     @Override
     public void action(Trip trip, Member member) {
         trip.leave(member);
-        trip.getTripMembers().forEach(this::publish);
+        trip.getTripMembers().forEach(tripMember -> publish(trip, tripMember.getMember()));
     }
 
-    private void publish(TripMember tripMember) {
+    private void publish(Trip trip, Member member) {
         tripMemberEventProducer.produceEvent(TripMemberEvent.builder()
-                .name(tripMember.getMember().getName())
-                .phoneNumber(tripMember.getMember().getPhoneNumber())
+                .tripId(trip.getId())
+                .name(member.getName())
+                .phoneNumber(member.getPhoneNumber())
                 .action(TripMemberEvent.Action.DELETE)
                 .build()
         );


### PR DESCRIPTION
## Issue
* resolved #72 

## 작업 사항
* verify-code API 응답에 회원가입 여부 추가
* 여행 인원이 모두 모집된 경우 FCM 알림 추가
* FCM에 payload 추가 -> FCM 클릭 시 화면으로 넘어가기 위한 값 (ex. tripId)