### PR TITLE
fix: trip 전체 조회 pet 필터 조건 수정

### DIFF
--- a/domain/src/main/java/com/tago/domain/course/repository/impl/CourseCustomRepositoryImpl.java
+++ b/domain/src/main/java/com/tago/domain/course/repository/impl/CourseCustomRepositoryImpl.java
@@ -1,6 +1,7 @@
 package com.tago.domain.course.repository.impl;
 
 import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.tago.domain.course.domain.Course;
 import com.tago.domain.course.repository.CourseCustomRepository;
@@ -46,8 +47,11 @@ public class CourseCustomRepositoryImpl implements CourseCustomRepository {
                 .distinct()
                 .innerJoin(course.coursePlaces, coursePlace).fetchJoin()
                 .innerJoin(coursePlace.place, place).fetchJoin()
-                .where(courseIdEq(id, placeId))
-                .orderBy(coursePlace.order.asc())
+                .where(courseIdEq(id, ids))
+                .orderBy(
+                        coursePlace.order.asc(),
+                        Expressions.numberTemplate(Double.class, "function('rand')").asc()
+                )
                 .fetchFirst();
     }
 
@@ -55,8 +59,8 @@ public class CourseCustomRepositoryImpl implements CourseCustomRepository {
         return placeId > 0 ? place.id.eq(placeId) : null;
     }
 
-    private BooleanExpression courseIdEq(Long courseId, Long placeId) {
-        return courseId != null ? course.id.eq(courseId) : placeIdEq(placeId);
+    private BooleanExpression courseIdEq(Long courseId, List<Long> courseIds) {
+        return courseId != null ? course.id.eq(courseId) : courseIdIn(courseIds);
     }
 
     private BooleanExpression courseIdIn(List<Long> courseIds) {

--- a/domain/src/main/java/com/tago/domain/trip/repository/impl/OriginTripJdbcRepositoryImpl.java
+++ b/domain/src/main/java/com/tago/domain/trip/repository/impl/OriginTripJdbcRepositoryImpl.java
@@ -20,10 +20,11 @@ public class OriginTripJdbcRepositoryImpl implements OriginTripJdbcRepository {
 
     @Override
     public void saveAll(List<OriginTripCreateDto> commands) {
-        String SQL = "INSERT INTO trip(name, date_time, meet_place, total_time, max_cnt, current_cnt, " +
+        String TRIP_SQL = "INSERT INTO trip(name, date_time, meet_place, total_time, max_cnt, current_cnt, " +
                 "same_gender, same_age, is_pet, origin, member_id, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, now(), now())";
 
-        jdbcTemplate.batchUpdate(SQL, new BatchPreparedStatementSetter() {
+        String TRIP_PLACE_SQL = "INSERT INTO trip_place()";
+        jdbcTemplate.batchUpdate(TRIP_SQL, new BatchPreparedStatementSetter() {
                 @Override
                 public void setValues(PreparedStatement ps, int i) throws SQLException {
                     OriginTripCreateDto command = commands.get(i);

--- a/domain/src/main/java/com/tago/domain/trip/repository/impl/TripCustomRepositoryImpl.java
+++ b/domain/src/main/java/com/tago/domain/trip/repository/impl/TripCustomRepositoryImpl.java
@@ -206,7 +206,7 @@ public class TripCustomRepositoryImpl implements TripCustomRepository {
         return trip.member.profile.gender.eq(memberGender);
     }
     private BooleanExpression isPet(Boolean isPet) {
-        return isPet ? trip.condition.isPet.eq(true) : null;
+        return isPet ? trip.condition.isPet.eq(false) : null;
     }
 
     private BooleanExpression memberEq(Member member) {


### PR DESCRIPTION
## Issue
* resolved #163 

## 작업 사항
* trip 전체 조회 pet 필터 수정
  * isPet이 true면 애완동물 싫어요! 여행 조회
  * 여행 생성 시에는 애완동물 싫어요 체크시 isPet false로 저장됨
  * 현재는 반대로 되어있는 상태 ... 이름때문에 헷갈려서 변수명을 바꿔야됨
* course 추천 API에서 place, tag에 매칭되는 course가 없는 경우 place가 포함된 course 반환하도록 수정