### PR TITLE
chore: redis 컨테이너 삭제 및 Elasticache host 연결

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,17 +1,9 @@
 version: '3.7'
 
 services:
-  redis:
-    image: redis:latest
-    command: redis-server
-    container_name: tago-redis
-    ports:
-      - "6379:6379"
   spring:
     image: 121284569119.dkr.ecr.ap-northeast-2.amazonaws.com/tago-dev:latest
     restart: always
-    depends_on:
-      - redis
     ports:
       - "8080:8080"
     container_name: tago-spring


### PR DESCRIPTION
## Issue
* resolved #161 

## Elasticache를 도입하게 된 이유
* redis 데이터를 유지하기 위함
  * 현재 서버 내에 docker 컨테이너로 redis를 띄워 사용하고 있음
  * redis에는 휴대폰 인증코드, fcm 토큰을 저장하고 있음
  * blue/green 배포 방식에 의해 배포 시 새로운 인스턴스를 띄우고, 시작 템플릿을 통해 환경을 세팅한 뒤 트래픽을 우회함
  * 따라서, 새로운 인스턴스에 redis 컨테이너가 새로 띄워지면서 데이터가 다 날아감
  * 또한, auto scaling에 의해 서버를 여러대 사용하는 경우 각 서버의 redis간의 데이터 정합성 문제 발생
  * Elasticache를 사용해 배포 시에도 redis 데이터 유지 및 데이터 정합성 문제 해결
* 프리티어가 지원되는 EC2 t2.micro 용량 사용 중, 메모리 부족 현상이 자주 발생
  *  인메모리 DB인 redis를 EC2 내부에 컨테이너로 띄워 사용하다보니 메모리 부족 현상이 자주 발생
  *  ElasticCache를 사용해 서버의 메모리 사용량 감소