### PR TITLE
refactor: 여행 참여하기/나가기 동시성 문제 해결

### DIFF
--- a/domain/build.gradle
+++ b/domain/build.gradle
@@ -14,6 +14,8 @@ dependencies {
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'
 
+    implementation 'org.redisson:redisson-spring-boot-starter:3.23.5'
+
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
 

--- a/domain/src/main/java/com/tago/domain/tripmember/service/TripMemberCreateService.java
+++ b/domain/src/main/java/com/tago/domain/tripmember/service/TripMemberCreateService.java
@@ -7,7 +7,10 @@ import com.tago.domain.tripmember.event.producer.TripMemberEvent;
 import com.tago.domain.tripmember.event.producer.TripMemberEventProducer;
 import com.tago.domain.tripmember.exception.AlreadyExistsTripMemberException;
 import com.tago.domain.tripmember.service.factory.TripMemberService;
+import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
 import org.springframework.stereotype.Service;
 
 
@@ -17,6 +20,7 @@ public class TripMemberCreateService implements TripMemberService {
 
     private static final String state = "ACCEPT";
     private final TripMemberEventProducer tripMemberEventProducer;
+    private final RedissonClient redissonClient;
 
     @Override
     public String getState() {
@@ -25,6 +29,25 @@ public class TripMemberCreateService implements TripMemberService {
 
     @Override
     public void action(Trip trip, Member member) {
+        String key = "LOCK-" + state + trip.getId();
+        RLock lock = redissonClient.getLock(key);
+
+        try {
+            boolean availableLock = lock.tryLock(3, 5, TimeUnit.SECONDS);
+
+            if (!availableLock) {
+                System.out.println("LOCK 획득 실패");
+                return;
+            }
+            create(trip, member);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    public void create(Trip trip, Member member) {
         validateJoinedAble(trip, member);
         trip.join(member);
         publishEvent(trip, member);

--- a/domain/src/main/java/com/tago/domain/tripmember/service/TripMemberDeleteService.java
+++ b/domain/src/main/java/com/tago/domain/tripmember/service/TripMemberDeleteService.java
@@ -9,7 +9,10 @@ import com.tago.domain.tripmember.event.producer.TripMemberEventProducer;
 import com.tago.domain.tripmember.exception.AlreadyExistsTripMemberException;
 import com.tago.domain.tripmember.handler.TripMemberQueryService;
 import com.tago.domain.tripmember.service.factory.TripMemberService;
+import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
 import org.springframework.stereotype.Service;
 
 
@@ -19,6 +22,7 @@ public class TripMemberDeleteService implements TripMemberService {
 
     private static final String state = "CANCEL";
     private final TripMemberEventProducer tripMemberEventProducer;
+    private final RedissonClient redissonClient;
 
     @Override
     public String getState() {
@@ -27,6 +31,25 @@ public class TripMemberDeleteService implements TripMemberService {
 
     @Override
     public void action(Trip trip, Member member) {
+        String key = "LOCK-" + state + trip.getId();
+        RLock lock = redissonClient.getLock(key);
+
+        try {
+            boolean availableLock = lock.tryLock(3, 5, TimeUnit.SECONDS);
+
+            if (!availableLock) {
+                System.out.println("LOCK 획득 실패");
+                return;
+            }
+            delete(trip, member);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    public void delete(Trip trip, Member member) {
         trip.leave(member);
         trip.getTripMembers().forEach(tripMember -> publish(trip, tripMember.getMember()));
     }

--- a/domain/src/test/resources/application-mysql.yml
+++ b/domain/src/test/resources/application-mysql.yml
@@ -25,6 +25,11 @@ server:
     connection-timeout: 300s
     keep-alive-timeout: 300s
 
+  data:
+    redis:
+      host: localhost
+      port: 6379
+
 jwt:
   secretKey: testtest!!
 


### PR DESCRIPTION
## 작업 사항
* Redis Redisson 라이브러리를 사용해 분산 락 구축
* 기존 동시성 문제는 아래와 같음
  * 같은 사용자가 동시에 2번 여행 참여 요청을 하는 경우 여행 멤버 중복에 대한 예외가 발생하지 않고, 중복으로 여행 멤버가 생성됨
  * 한 자리가 남은 경우 동시에 여행 참여하기 요청이 들어오면 두 요청 모두 여행 멤버가 생성됨
  * 동시에 여러 멤버가 여행 참여를 요청하는 경우 여행 참여 인원 수 업데이트가 제대로 안됨
  * 여행 나가기 요청도 이와 마찬가지
* 따라서, 분산락을 통해 여행 참여하기/나가기 로직은 한 번에 한 스레드만 접근할 수 있도록 구현