### PR TITLE
fix: 트랜잭션 전파 속성에 의한 동시성 문제 재발 해결

### DIFF
--- a/api/src/main/java/com/tago/api/tripmember/application/TripMemberSaveService.java
+++ b/api/src/main/java/com/tago/api/tripmember/application/TripMemberSaveService.java
@@ -8,8 +8,7 @@ import com.tago.domain.member.handler.MemberQueryService;
 import com.tago.domain.trip.domain.Trip;
 import com.tago.domain.trip.handler.TripQueryService;
 import com.tago.domain.tripmember.handler.TripMemberQueryService;
-import com.tago.domain.tripmember.service.factory.TripMemberService;
-import com.tago.domain.tripmember.service.factory.TripMemberServiceFactory;
+import com.tago.domain.tripmember.service.TripMemberFacade;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -20,17 +19,13 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class TripMemberSaveService {
 
-    private final TripMemberServiceFactory tripMemberServiceFactory;
+    private final TripMemberFacade tripMemberFacade;
     private final TripMemberQueryService tripMemberQueryService;
     private final TripQueryService tripQueryService;
-    private final MemberQueryService memberQueryService;
 
     @Transactional
     public void joinOrLeave(Long tripId, Long memberId, String state){
-        Trip trip = tripQueryService.findByIdFetchTripMember(tripId);
-        Member member = memberQueryService.findById(memberId);
-        TripMemberService service = tripMemberServiceFactory.getInstance(state);
-        service.action(trip, member);
+        tripMemberFacade.createOrDelete(tripId, memberId, state);
     }
 
     @Transactional(readOnly = true)

--- a/api/src/main/resources/application.yml
+++ b/api/src/main/resources/application.yml
@@ -4,6 +4,8 @@ spring:
     username: ${DATABASE_USERNAME}
     password: ${DATABASE_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver
+    hikari:
+      maximum-pool-size: 11
   sql:
     init:
       mode: never

--- a/domain/src/main/java/com/tago/domain/trip/service/TripCreateService.java
+++ b/domain/src/main/java/com/tago/domain/trip/service/TripCreateService.java
@@ -40,7 +40,7 @@ public class TripCreateService {
 
         trip.addTripPlaces(tripPlaceCreateService.createTripPlaces(trip, dto.getPlaces()));
         trip.addTripTags(tripTagCreateService.createTripTags(trip, dto.getTypes()));
-        tripMemberCreateService.action(trip, member);
+        tripMemberCreateService.action(trip.getId(), member.getId());
 
         return tripCommandService.save(trip);
     }

--- a/domain/src/main/java/com/tago/domain/tripmember/service/TripMemberCreateService.java
+++ b/domain/src/main/java/com/tago/domain/tripmember/service/TripMemberCreateService.java
@@ -1,8 +1,12 @@
 package com.tago.domain.tripmember.service;
 
 
+import static com.tago.domain.trip.domain.QTrip.trip;
+
 import com.tago.domain.member.domain.Member;
+import com.tago.domain.member.handler.MemberQueryService;
 import com.tago.domain.trip.domain.Trip;
+import com.tago.domain.trip.handler.TripQueryService;
 import com.tago.domain.tripmember.event.producer.TripMemberEvent;
 import com.tago.domain.tripmember.event.producer.TripMemberEventProducer;
 import com.tago.domain.tripmember.exception.AlreadyExistsTripMemberException;
@@ -12,6 +16,8 @@ import lombok.RequiredArgsConstructor;
 import org.redisson.api.RLock;
 import org.redisson.api.RedissonClient;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
 
 
 @RequiredArgsConstructor
@@ -20,7 +26,8 @@ public class TripMemberCreateService implements TripMemberService {
 
     private static final String state = "ACCEPT";
     private final TripMemberEventProducer tripMemberEventProducer;
-    private final RedissonClient redissonClient;
+    private final MemberQueryService memberQueryService;
+    private final TripQueryService tripQueryService;
 
     @Override
     public String getState() {
@@ -28,28 +35,14 @@ public class TripMemberCreateService implements TripMemberService {
     }
 
     @Override
-    public void action(Trip trip, Member member) {
-        String key = "LOCK-" + state + trip.getId();
-        RLock lock = redissonClient.getLock(key);
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void action(Long tripId, Long memberId) {
+        Trip trip = tripQueryService.findById(tripId);
+        Member member = memberQueryService.findById(memberId);
 
-        try {
-            boolean availableLock = lock.tryLock(3, 5, TimeUnit.SECONDS);
-
-            if (!availableLock) {
-                System.out.println("LOCK 획득 실패");
-                return;
-            }
-            create(trip, member);
-        } catch (InterruptedException e) {
-            e.printStackTrace();
-        } finally {
-            lock.unlock();
-        }
-    }
-
-    public void create(Trip trip, Member member) {
         validateJoinedAble(trip, member);
         trip.join(member);
+
         publishEvent(trip, member);
     }
 

--- a/domain/src/main/java/com/tago/domain/tripmember/service/TripMemberDeleteService.java
+++ b/domain/src/main/java/com/tago/domain/tripmember/service/TripMemberDeleteService.java
@@ -2,7 +2,9 @@ package com.tago.domain.tripmember.service;
 
 
 import com.tago.domain.member.domain.Member;
+import com.tago.domain.member.handler.MemberQueryService;
 import com.tago.domain.trip.domain.Trip;
+import com.tago.domain.trip.handler.TripQueryService;
 import com.tago.domain.tripmember.domain.TripMember;
 import com.tago.domain.tripmember.event.producer.TripMemberEvent;
 import com.tago.domain.tripmember.event.producer.TripMemberEventProducer;
@@ -22,7 +24,8 @@ public class TripMemberDeleteService implements TripMemberService {
 
     private static final String state = "CANCEL";
     private final TripMemberEventProducer tripMemberEventProducer;
-    private final RedissonClient redissonClient;
+    private final TripQueryService tripQueryService;
+    private final MemberQueryService memberQueryService;
 
     @Override
     public String getState() {
@@ -30,26 +33,10 @@ public class TripMemberDeleteService implements TripMemberService {
     }
 
     @Override
-    public void action(Trip trip, Member member) {
-        String key = "LOCK-" + state + trip.getId();
-        RLock lock = redissonClient.getLock(key);
+    public void action(Long tripId, Long memberId) {
+        Trip trip = tripQueryService.findById(tripId);
+        Member member = memberQueryService.findById(memberId);
 
-        try {
-            boolean availableLock = lock.tryLock(3, 5, TimeUnit.SECONDS);
-
-            if (!availableLock) {
-                System.out.println("LOCK 획득 실패");
-                return;
-            }
-            delete(trip, member);
-        } catch (InterruptedException e) {
-            e.printStackTrace();
-        } finally {
-            lock.unlock();
-        }
-    }
-
-    public void delete(Trip trip, Member member) {
         trip.leave(member);
         trip.getTripMembers().forEach(tripMember -> publish(trip, tripMember.getMember()));
     }

--- a/domain/src/main/java/com/tago/domain/tripmember/service/TripMemberFacade.java
+++ b/domain/src/main/java/com/tago/domain/tripmember/service/TripMemberFacade.java
@@ -1,0 +1,41 @@
+package com.tago.domain.tripmember.service;
+
+import com.tago.domain.tripmember.service.factory.TripMemberService;
+import com.tago.domain.tripmember.service.factory.TripMemberServiceFactory;
+import java.util.concurrent.TimeUnit;
+import lombok.RequiredArgsConstructor;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Service
+public class TripMemberFacade {
+
+    private final TripMemberServiceFactory tripMemberServiceFactory;
+    private final RedissonClient redissonClient;
+
+    @Transactional
+    public void createOrDelete(Long tripId, Long memberId, String state) {
+        TripMemberService tripMemberService = tripMemberServiceFactory.getInstance(state);
+
+        String key = "LOCK-" + state + "-" + tripId;
+        RLock lock = redissonClient.getLock(key);
+
+        try {
+            boolean availableLock = lock.tryLock(5, 3, TimeUnit.SECONDS);
+
+            if (!availableLock) {
+                System.out.println("LOCK 획득 실패");
+                return;
+            }
+
+            tripMemberService.action(tripId, memberId);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        } finally {
+            lock.unlock();
+        }
+    }
+}

--- a/domain/src/main/java/com/tago/domain/tripmember/service/factory/TripMemberService.java
+++ b/domain/src/main/java/com/tago/domain/tripmember/service/factory/TripMemberService.java
@@ -1,8 +1,5 @@
 package com.tago.domain.tripmember.service.factory;
 
-import com.tago.domain.member.domain.Member;
-import com.tago.domain.trip.domain.Trip;
-
 public interface TripMemberService {
     String getState();
     void action(Long tripId, Long memberId);

--- a/domain/src/main/java/com/tago/domain/tripmember/service/factory/TripMemberService.java
+++ b/domain/src/main/java/com/tago/domain/tripmember/service/factory/TripMemberService.java
@@ -5,5 +5,5 @@ import com.tago.domain.trip.domain.Trip;
 
 public interface TripMemberService {
     String getState();
-    void action(Trip trip, Member member);
+    void action(Long tripId, Long memberId);
 }

--- a/domain/src/test/java/com/tago/domain/TripMemberFacadeTest.java
+++ b/domain/src/test/java/com/tago/domain/TripMemberFacadeTest.java
@@ -1,0 +1,162 @@
+package com.tago.domain;
+
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.tago.domain.member.domain.Member;
+import com.tago.domain.member.domain.vo.Gender;
+import com.tago.domain.member.domain.vo.Mbti;
+import com.tago.domain.member.domain.vo.Profile;
+import com.tago.domain.member.domain.vo.Role;
+import com.tago.domain.member.repository.MemberRepository;
+import com.tago.domain.trip.domain.Trip;
+import com.tago.domain.trip.repository.TripRepository;
+import com.tago.domain.tripmember.dto.TripMemberDto;
+import com.tago.domain.tripmember.repository.TripMemberRepository;
+import com.tago.domain.tripmember.service.TripMemberFacade;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@ActiveProfiles("mysql")
+@SpringBootTest
+public class TripMemberFacadeTest {
+
+    @Autowired
+    private TripRepository tripRepository;
+
+    @Autowired
+    private TripMemberRepository tripMemberRepository;
+
+    @Autowired
+    private TripMemberFacade tripMemberFacade;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @AfterEach
+    public void after() {
+        tripRepository.deleteAll();
+        memberRepository.deleteAll();
+    }
+
+    /**
+     * GIVEN 최대 인원 수 10명인 여행 생성 및 여행에 참여하려는 멤버 10명 생성
+     * WHEN 10명의 멤버가 동시에 여행 참여 요청
+     * THEN 여행 참여 인원 수 10, 해당 여행 멤버 수 10
+     */
+    @Test
+    void 동시에_10명_참여하기_요청() throws InterruptedException {
+        Trip mockTrip = createMockTrip(10, 0);
+
+        concurrencyTest(() -> {
+            Member member = createMockMember();
+            tripMemberFacade.createOrDelete(mockTrip.getId(), member.getId(), "ACCEPT");
+        }, 10);
+
+        Trip trip = tripRepository.findById(mockTrip.getId()).orElseThrow();
+        List<TripMemberDto> tripMembers = tripMemberRepository.findMembersByTrip(mockTrip);
+
+        assertThat(trip.getCurrentCnt()).isEqualTo(10);
+        assertThat(tripMembers.size()).isEqualTo(10);
+    }
+
+    /**
+     * GIVEN 여행 및 여행에 참여하려는 멤버 생성
+     * WHEN 같은 멤버가 동시에 여행 참여 중복 요청 (더블 클릭과 같은 이유로)
+     * THEN 여행 중복 참여가 불가능하므로, 한 개의 참여 요청만 수락
+     */
+    @Test
+    void 같은_멤버가_여행_참여하기_중복_요청() throws InterruptedException {
+        Trip mockTrip = createMockTrip(10, 0);
+        Member mockMember = createMockMember();
+
+        concurrencyTest(() -> {
+            tripMemberFacade.createOrDelete(mockTrip.getId(), mockMember.getId(), "ACCEPT");
+        }, 2);
+
+        Trip trip = tripRepository.findById(mockTrip.getId()).orElseThrow();
+        List<TripMemberDto> tripMembers = tripMemberRepository.findMembersByTrip(mockTrip);
+
+        assertThat(trip.getCurrentCnt()).isEqualTo(1);
+        assertThat(tripMembers.size()).isEqualTo(1);
+    }
+
+    /**
+     * GIVEN 정원이 1명 남은 여행 생성 및 여행에 참여하려는 멤버 2명 생성
+     * WHEN 2명의 멤버가 동시에 여행 참여 요청
+     * THEN 한 명의 여행 참여 요청만 수락
+     */
+    @Test
+    void 한자리_남은_여행에_2명이_동시에_참여하기_요청() throws InterruptedException {
+        Trip mockTrip = createMockTrip(1, 0);
+
+        concurrencyTest(() -> {
+            Member member = createMockMember();
+            tripMemberFacade.createOrDelete(mockTrip.getId(), member.getId(), "ACCEPT");
+        }, 2);
+
+        Trip trip = tripRepository.findByIdFetchTripMember(mockTrip.getId()).orElseThrow();
+        List<TripMemberDto> tripMembers = tripMemberRepository.findMembersByTrip(mockTrip);
+
+        assertThat(trip.getCurrentCnt()).isEqualTo(1);
+        assertThat(tripMembers.size()).isEqualTo(1);
+    }
+
+    private void concurrencyTest(Runnable runnable, int threadCount) throws InterruptedException {
+        ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch countDownLatch = new CountDownLatch(threadCount);
+
+        for(int i = 0; i < threadCount; i++) {
+            executorService.submit(() -> {
+                try {
+                    runnable.run();
+                } finally {
+                    countDownLatch.countDown();
+                }
+            });
+        }
+        countDownLatch.await();
+    }
+
+    private Member createMockMember() {
+        Profile profile = Profile.builder()
+                .imgUrl("test")
+                .ageRange(20)
+                .gender(Gender.MALE)
+                .mbti(Mbti.ENFJ)
+                .tripTypes(List.of())
+                .build();
+        Member member = Member.builder()
+                .phoneNumber(UUID.randomUUID().toString())
+                .name("이하늘")
+                .role(Role.USER)
+                .profile(profile)
+                .build();
+        return memberRepository.save(member);
+    }
+
+    private Trip createMockTrip(int maxCnt, int currentCnt) {
+        Trip trip = Trip.builder()
+                .name("회먹고 곱창먹는 여행")
+                .dateTime(LocalDateTime.now())
+                .meetPlace("해운대")
+                .totalTime(8)
+                .maxCnt(maxCnt)
+                .currentCnt(currentCnt)
+                .condition(null)
+                .member(null)
+                .origin(false)
+                .build();
+        return tripRepository.save(trip);
+    }
+}

--- a/domain/src/test/resources/application-mysql.yml
+++ b/domain/src/test/resources/application-mysql.yml
@@ -4,6 +4,8 @@ spring:
     url: jdbc:mysql://localhost:3306/tago2?rewriteBatchedStatements=true
     username: root
     password: 1234
+    hikari:
+      maximum-pool-size: 11
 
   jpa:
     hibernate:


### PR DESCRIPTION
## 문제 상황
* 기존에는 TripMemberCreateService의 action메소드 내부에 락 관련 로직이 존재했습니다.
* 그리고, action 메소드를 application 서비스에서 호출함으로써 기본 전파 속성에 의해 락 관련 로직이 부모 트랜잭션에 합류했습니다.
* 이 경우, 락의 해제가 트랜잭션 커밋보다 먼저 이루어지게 됩니다. 이로 인해, 공유자원을 업데이트한 값이 즉시 DB에 반영되지 않아 다음으로 락을 획득한 스레드에서 제대로된 공유자원을 조회할 수 없게 됩니다. 
* 아래와 같이 Thread A가 커밋되기 전 락을 획득한 Thread B에서 업데이트되지 않은 값을 조회해 여행 참여 인원 수는 1만 증가하게 됩니다.
  *  여행 멤버는 2명이 생성되었지만, 여행 참여 인원 수는 1 증가된 상황
* 즉, 락의 해제가 트랜잭션 커밋보다 먼저 이뤄져 데이터의 정합성이 깨졌고,  동시성 문제가 재발했습니다.

<img width="700" alt="image" src="https://github.com/TraviTago/tago-api/assets/50009240/d1087da3-bce3-4bf0-90e2-5e59761f4f46">

## 문제 해결
* 락 관련 로직과 공유자원에 접근하는 로직의 트랜잭션을 분리했습니다.
* TripMemberFacade에서 락을 획득하고, TripMemberCreateService의 action 메소드를 호출합니다.
* REQUIRES_NEW 전파 속성에 의해 action 메소드는 새로운 트랜잭션을 생성합니다.
* 새로운 트랜잭션에서 공유 자원을 업데이트한 뒤 트랜잭션을 커밋하고, TripMemberFacade에서 락을 해제합니다.
* 이 경우, 두 사용자가 동시에 여행 참여를 요청해도 정상적으로 여행 참여 인원 수가 증가되게 됩니다. 락 해제가 트랜잭션 커밋보다 뒤에 이뤄진 덕분에 동시성 환경에서도 데이터 정합성을 보장할 수 있습니다.

## 트러블 슈팅
* HikariCP에 대한 Thread간 Dead lock이 발생했습니다. 
* 락 관련 로직과 공유자원에 접근하는 로직의 트랜잭션을 분리했기에 여행 참여 요청에 대해 2개의 데이터베이스 커넥션이 필요했습니다.
* 이로 인해, Thread간 Connection을 차지하기 위한 Race Condition이 발생했고, 이는 HikariCP에 대한 Dead lock으로 이어졌습니다.
* 이를 해결하기 위해, HikariCP Wiki에서 제공하는 데드락을 방지하기 위한 커넥션 풀 사이즈 공식에 따라 HikariCP Maximum pool size를 설정했습니다. 
```
pool size = Tn x (Cm - 1) + 1
```
```
spring:
  datasource:
    hikari:
      maximum-pool-size: 11
```
* 이를 통해 HikariCP에 대한 데드락은 해결했지만, 이는 데드락을 피하기 위한 최소 커넥션 풀 사이즈입니다. 
* 추후 성능 테스트를 통해 최적의 Pool Size를 찾아볼 예정입니다.